### PR TITLE
docs: Add docker-compose example for Docker Hub users

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,29 @@ Choose one of the following installation methods:
    STATION_ID=<Your Station ID>
    ```
 
-3. **Start the container**
+3. **Create docker-compose.yaml** (if pulling from Docker Hub)
+
+   If you're pulling the pre-built image from Docker Hub instead of building locally, create a `docker-compose.yaml`:
+
+   ```yaml
+   services:
+     amber2sigen:
+       image: talie5in/amber2sigen:latest
+       container_name: amber2sigen
+       restart: unless-stopped
+       env_file:
+         - amber2sigen.env
+   ```
+
+   > **Important:** Use `env_file` to load your environment variables, not `volumes`. The `env_file` directive tells Docker Compose to read the file and set each line as an environment variable inside the container. Volume mounting the file does **not** set environment variables.
+
+4. **Start the container**
 
    ```bash
    docker compose up -d
    ```
 
-4. **View logs**
+5. **View logs**
 
    ```bash
    docker compose logs -f


### PR DESCRIPTION
## Summary

Added Step 3 to the Docker Quick Start guide showing how to create a `docker-compose.yaml` when pulling the pre-built image from Docker Hub.

### Changes
- Added docker-compose example specifically for users pulling from Docker Hub (vs building locally)
- Added important note explaining why `env_file` must be used instead of volume mounting
- Renumbered subsequent steps (4 → Start container, 5 → View logs)

### Why this is needed

As discussed in #6, users pulling the Docker image from Docker Hub may not have the repo's `docker-compose.yml` file and were incorrectly using volume mounts to load their env file:

```yaml
# ❌ WRONG - volume mount doesn't set env vars
volumes:
  - ./amber2sigen.env:/etc/amber2sigen.env
```

```yaml
# ✅ CORRECT - env_file sets env vars in container
env_file:
  - amber2sigen.env
```

Closes #6